### PR TITLE
fix: remove wrong tslint rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,7 @@
   "rules": {
       "trailing-comma": [ false ],
       "semicolon": [true, "never"],
-      "quotemark": [true, "single", "backtick"],
+      "quotemark": [true, "single"],
       "no-console": [false],
       "variable-name": [
         true,


### PR DESCRIPTION
Remove wrong quotemark rule `backtick` option 